### PR TITLE
fix: crash on android if title/text property is a number

### DIFF
--- a/src/utils/AccessibilityHelper.android.ts
+++ b/src/utils/AccessibilityHelper.android.ts
@@ -612,8 +612,8 @@ const applyContentDescription = profile('applyContentDescription', function appl
     return null;
   }
 
-  const titleValue = ((tnsView['title'] as string) || '').trim();
-  const textValue = ((tnsView['text'] as string) || '').trim();
+  const titleValue = ((tnsView['title'] as string) || '').toString().trim();
+  const textValue = ((tnsView['text'] as string) || '').toString().trim();
 
   if (!forceUpdate && tnsView._androidContentDescriptionUpdated === false && textValue === tnsView['_lastText'] && titleValue === tnsView['_lastTitle']) {
     // prevent updating this too much


### PR DESCRIPTION
Android would crash if a label was of type `number`. This fix casts the value `toString()` before attempting to `trim()` to ensure the crash doesn't occur.

I couldn't see the branch for `v7.0.0-alpha.1`, assuming this is the correct place?