### PR TITLE
handle missing getAccessibilityDelegate()

### DIFF
--- a/packages/nativescript-accessibility-ext/utils/accessibility-helper.android.ts
+++ b/packages/nativescript-accessibility-ext/utils/accessibility-helper.android.ts
@@ -567,7 +567,7 @@ function setAccessibilityDelegate(tnsView: TNSView) {
 
   androidViewToTNSView.set(androidView, new WeakRef(tnsView));
 
-  const hasOldDelegate = androidView.getAccessibilityDelegate() === TNSAccessibilityDelegate;
+  const hasOldDelegate = ( androidView.getAccessibilityDelegate ? androidView.getAccessibilityDelegate() === TNSAccessibilityDelegate : androidView.AccessibilityDelegate === TNSAccessibilityDelegate );
 
   const cls = `AccessibilityHelper.updateAccessibilityProperties(${tnsView}) - has delegate? ${hasOldDelegate}`;
   if (isTraceEnabled()) {


### PR DESCRIPTION
On Nativescript version 7.1.2 (using Vue) we installed nativescript-accessibility-ext version 7.0.1.  It errored because getAccessibilityDelegate() undefined.  This fixed it for us.